### PR TITLE
Feature/composer binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# cli
+
+A CLI interface for BookStack.
+
+## Installation
+
+Via Composer (not available on Packagist)
+
+``` bash
+$ composer global require bookstackapp/cli
+```
+
+## Usage
+
+When installing through Composer globally, it should include the `bookstack` binary in your path.
+
+**Updates the vendor directory without composer:**
+
+```bash
+bookstack update:vendor {--force}
+```
+
+## License
+
+The MIT License (MIT).

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,8 @@
     },
     "require": {
         "symfony/console": "^3.1"
-    }
+    },
+    "bin": [
+        "bookstack"
+    ]
 }


### PR DESCRIPTION
I know this isn't available on Packagist, but it's quite useful to have the binary listed in the `bin` array. Especially if this is being used in an internal package host.

I've also added a basic [`README`](/pxgamer/bookstack-cli/blob/feature/composer-binary/README.md) just for information.